### PR TITLE
ci: add multi-arch build test via cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,57 @@ name: Build
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
+  multi-platform-build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
+    strategy:
+      matrix:
+        include:
+          - { plat: ubuntu-latest, arch: x86_64 }
+          - { plat: ubuntu-latest, arch: i686 }
+          - { plat: ubuntu-latest, arch: ppc64le, qemu: true }
+          # Linux: s390x fails test: "FAILED tests/test_convert.py::test_main - assert <EResult.InvalidMagicNumber:..."
+          #- { plat: ubuntu-latest, arch: s390x, qemu: true }
+          - { plat: ubuntu-24.04-arm, arch: aarch64 }
+          - { plat: ubuntu-24.04-arm, arch: armv7l }
+          # Linux ARM: QEMU-emulated builds fail with segmentation faults
+          #- { plat: ubuntu-24.04-arm, arch: ppc64le, qemu: true }
+          #- { plat: ubuntu-24.04-arm, arch: s390x, qemu: true }
+          # macOS ARM build somehow compiles x86_64 deps (macos-latest/macos-14 is ARM)
+          #- { plat: macos-latest, arch: arm64 }
+          # macOS ARM runners do not support Docker (yet), but macOS 13 runner is x86_64
+          - { plat: macos-13, arch: x86_64 }
+          - { plat: windows-latest, arch: AMD64 }
+          # Windows 32-bit builds fail
+          #- { plat: windows-latest, arch: x86 }
+      fail-fast: false
+    name: ${{ matrix.arch }} on ${{ matrix.plat }}
+    runs-on: ${{ matrix.plat }}
+    env:
+      # Skip PyPy builds for now
+      CIBW_SKIP: pp*
+    steps:
+    - uses: actions/checkout@v4
+    # Linux: Workaround for missing PIC error when linking heatshrink_dynalloc
+    - if: ${{ matrix.plat == 'ubuntu-latest' }}
+      run: sed -i '1i\set(CMAKE_POSITION_INDEPENDENT_CODE ON)' deps/heatshrink/CMakeLists.txt
+    - uses: actions/setup-python@v5
+    - if: ${{ matrix.qemu }}
+      uses: docker/setup-qemu-action@v3
+    - run: python -m pip install cibuildwheel
+    - run: python -m cibuildwheel --archs ${{ matrix.arch }} --output-dir build
+    - run: ls -l build
+
   build-linux:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -105,6 +150,7 @@ jobs:
         path: ${{github.workspace}}/dist/
 
   build-wasm:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: ubuntu-latest
     container:
       image: emscripten/emsdk
@@ -194,6 +240,7 @@ jobs:
         path: ${{github.workspace}}/build/dist/lib/wasm/
 
   build-msvc:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     runs-on: windows-2019
 
     strategy:
@@ -292,6 +339,7 @@ jobs:
         path: ${{github.workspace}}\dist\
 
   build-mac:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/pybgcode/CMakeLists.txt
+++ b/pybgcode/CMakeLists.txt
@@ -23,7 +23,7 @@ else ()
     add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/upstream)
 endif ()
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 REQUIRED)
 
 set(PY_VERSION_SUFFIX "")


### PR DESCRIPTION
cibuildwheel builds wheels for various platforms and Python implementations and versions, making use of QEMU emulation for cross-compiling. As such it is an easy way to generate pre-compiled binaries for PyPI. For now, it is added hereby as an additional test, which can be extended to upload wheels as GitHub assets and/or to PyPI.

Additional fixes:
- ci: workflows previously ran concurrently, when multiple triggeres happened too soon. A concurrency handling is implemented to automatically cancel workflows originating from the same trigger on the same branch/reference.
- ci: on pull request updates from a branch on the repository, all jobs ran twice, once for the push trigger, once for the pull_request trigger. A condition is added to each job, to run the pull_request triggered job only for pull requests from other repositories (forks). In such case, the push trigger run on the head repository, so contributors can review and manage tests on their fork, while the pull_request trigger runs on the base repository, so the project owner can review and manage tests on their repository as well, and results are shown in the PR, and can be configured to block merging. If someone opens a PR on the own repo, and pushes code, only the push triggered tests run, which are then shown as well in the PR, and can block it, if configured.
- cmake: Newer cmake versions fail as well on the "find_package(Python3 ..." statement without adjustment, despite the syntax being correct. Background: https://github.com/scikit-build/scikit-build-core/issues/173, https://github.com/pypa/cibuildwheel/issues/639

@jneilliii 
For whatever reason, builds within `cibuildwheel` fail to link `heatshrink_dynalloc`, complaining about missing PIC (position independent code) for shared objects. When I build it on my test VM directly, it works, the other build jobs also succeed, as well as your builds, obviously. Only solution I could find was to set `CMAKE_POSITION_INDEPENDENT_CODE` for the heatshrink build, to pass `-fPIC` to the compiler.
- First of all, not sure whether I understood from the code and its comment, how the dependencies are linked into `libbgcode`. For platform-independent wheels I'd expect static links. This also seems to be the case at least for all other dependencies, while only `libbgcode` itself is compiled as shared object, and bundled with the wheel?
- Above flag is set in some other cases, like `pyproject.toml` passes `PyBGCode_LINK_SYSTEM_LIBBGCODE=off` which leads to the flag set in `pybgcode/CMakeList.txt`, but it is not passed through to the dependencies builds, obviously. If `BUILD_SHARED_LIBS` is passed through to the deps build, the flag is set for all individual deps builds, but it has also other effects, likely building all dependencies as shared libraries to be dynamically linked, which is not what we want.
- Now, while dependencies are supposed to be statically linked, `heatshrink_dynalloc` alone from the name is a shared object? From the cmake files, I see there are two variants compiled `heatshrink` and `heatshrink_dynalloc`, which sounds like one would be for static linking and one for dynamic or so. But I don't even know what this library does, so probably I am misunderstanding it. In any case, both are linked into `libbgcode`, but only `heatshrink_dynalloc` fails.
- I first tried to set above flag only here, for the 2nd one particularly:
    ```cmake
    target_compile_definitions(${PROJECT_NAME}_dynalloc PUBLIC HEATSHRINK_DYNAMIC_ALLOC=1)
    ```
    which seems to me made for this, like so:
    ```cmake
    target_compile_definitions(${PROJECT_NAME}_dynalloc PUBLIC HEATSHRINK_DYNAMIC_ALLOC=1 CMAKE_POSITION_INDEPENDENT_CODE=ON)
    ```
    but that did not work. Only setting it in `deps/heatshrink/CMakeLists.txt` for both works.

Maybe you have an idea why this happens, respectively why only in `cibuildwheel` (for now), probably due to newer compiler(s). And maybe there is a more elegant solution for it. However, I did not want to change the code to fix an issue, which appears in CI only (for now), hence it is just done as part of the workflow.

Creating it as draft, until the job is green.