### PR TITLE
cmake: fix find_package statement for ZLIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ install(TARGETS ${_libname}
     INCLUDES DESTINATION include/${PROJECT_NAME}
 )
 
-find_package(ZLIB REQUIRED "1.0")
+find_package(ZLIB "1.0" REQUIRED)
 
 foreach(_comp ${_selected_components})
     # Install targets and headers


### PR DESCRIPTION
The ZLIB dependency was added with wrong syntax, which is `find_package(<PackageName> [<version>] [REQUIRED] ...)`. Newer `cmake` versions seem to have issues with the version and `REQUIRED` arguments swapped: https://cmake.org/cmake/help/latest/command/find_package.html

I recognised the commit which added the statement is no upstream yet, hence solving it here first. The failing macOS builds are solved upstream, merged with #2.