### PR TITLE
ci: give all artifacts individiual names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
-        name: test-results
+        name: test-results-linux
         path: ${{github.workspace}}/build/**/result-junit-linux.xml
     
     - uses: actions/upload-artifact@v4  # upload python module
@@ -183,7 +183,7 @@ jobs:
     - uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
-        name: test-results
+        name: test-results-wasm
         path: ${{github.workspace}}/build/**/result-junit-wasm.xml
 
     - uses: actions/upload-artifact@v4  # upload wasm module
@@ -384,7 +384,7 @@ jobs:
     - uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
-        name: test-results
+        name: test-results-mac
         path: ${{github.workspace}}/build/**/result-junit-mac.xml
 
     - uses: actions/upload-artifact@v4  # upload python module


### PR DESCRIPTION
upload-artifacts v4 requires each upload in the workflow to have an individual name: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

The suffix for the related job is hence added, which was the case for the msvc test results already, and matches the XML file suffix as well. The test workflow picks up the artifacts with any suffix already.

_My forced push at #4 came a little too late 😅, Internet here in the aircraft during flight is a little slow 🤔. Opening this one as draft first, to assure all but macOS tests turn green now._