### PR TITLE
ci: address warnings emitted by workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
     - run: python -m pip install cibuildwheel
     - run: python -m cibuildwheel --archs ${{ matrix.arch }} --output-dir build
     - run: ls -l build
+    - uses: actions/upload-artifact@v4
+      with:
+        name: libbgcode-python-${{ matrix.plat }}-${{ matrix.arch }}
+        path: build
 
   build-linux:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
     - if: ${{ matrix.plat == 'ubuntu-latest' }}
       run: sed -i '1i\set(CMAKE_POSITION_INDEPENDENT_CODE ON)' deps/heatshrink/CMakeLists.txt
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        check-latest: true
     - if: ${{ matrix.qemu }}
       uses: docker/setup-qemu-action@v3
     - run: python -m pip install cibuildwheel

--- a/deps/Boost/Boost.cmake
+++ b/deps/Boost/Boost.cmake
@@ -1,6 +1,6 @@
 add_cmake_project(Boost
-    URL "https://github.com/boostorg/boost/releases/download/boost-1.82.0/boost-1.82.0.zip"
-    URL_HASH SHA256=200f9292b5ef957ab551a648834239f502df165cb7bff18432702fb7ae98accb
+    URL "https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.zip"
+    URL_HASH SHA256=68cf5e488c9e6315ee101460b216cc0da6a401e527ff53446122d8c047a8fab3
     LIST_SEPARATOR |
     CMAKE_ARGS
         -DBOOST_INCLUDE_LIBRARIES:STRING=beast|nowide


### PR DESCRIPTION
> The `python-version` input is not set. The version of Python currently in `PATH` will be used.

> cibuildwheel 3 will require Python 3.11+, please upgrade the Python version used to run cibuildwheel. This does not affect the versions you can target when building wheels. See: https://cibuildwheel.pypa.io/en/stable/#what-does-it-do

Use latest Python 3 for the build host to address both.