### PR TITLE
packaging: rename project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(LibBGCode VERSION ${LibBGCode_VERSION})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(PROJECT_NAME "libbgcode")
 set(_libname ${PROJECT_NAME})
 string(TOLOWER ${_libname} _libname)
 string(REPLACE "lib" "" _libname ${_libname})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ project(LibBGCode VERSION ${LibBGCode_VERSION})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(PROJECT_NAME "libbgcode")
 set(_libname ${PROJECT_NAME})
 string(TOLOWER ${_libname} _libname)
 string(REPLACE "lib" "" _libname ${_libname})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,9 @@ requires-python = ">=3.7"
 requires = ["py-build-cmake~=0.1.8", "pytest"]
 build-backend = "py_build_cmake.build"
 
-[tool.setuptools]
-packages = [
-  "pybgcode",
-]
-include-package-data = true
-package-dir = { "" = "pybgcode/" }
-
-# [tool.py-build-cmake.module] # Where to find the Python module to package
-# directory = "pybgcode/"
+[tool.py-build-cmake.module] # Where to find the Python module to package
+name = "pybgcode"
+directory = "pybgcode/"
 
 [tool.py-build-cmake.sdist] # What to include in source distributions
 include = [ "pybgcode/*", "src/*" , "deps/*", "deps/build.cmake", "cmake/*", "CMakeLists.txt", "CMakePresets.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,15 @@ requires-python = ">=3.7"
 requires = ["py-build-cmake~=0.1.8", "pytest"]
 build-backend = "py_build_cmake.build"
 
-[tool.py-build-cmake.module] # Where to find the Python module to package
-directory = "pybgcode/"
+[tool.setuptools]
+packages = [
+  "pybgcode",
+]
+include-package-data = true
+package-dir = { "" = "pybgcode/" }
+
+# [tool.py-build-cmake.module] # Where to find the Python module to package
+# directory = "pybgcode/"
 
 [tool.py-build-cmake.sdist] # What to include in source distributions
 include = [ "pybgcode/*", "src/*" , "deps/*", "deps/build.cmake", "cmake/*", "CMakeLists.txt", "CMakePresets.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pybgcode"
+name = "pybgcode-jneilliii"
 version = "0.2.0"
 description = "Prusa Block & Binary G-code reader / writer / converter"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pybgcode"
+name = "pybgcode-jneilliii"
 version = "0.2.0"
 description = "Prusa Block & Binary G-code reader / writer / converter"
 authors = [
@@ -23,14 +23,14 @@ requires = ["py-build-cmake~=0.1.8", "pytest"]
 build-backend = "py_build_cmake.build"
 
 [tool.py-build-cmake.module] # Where to find the Python module to package
-directory = "pybgcode/"
+directory = "pybgcode"
 
 [tool.py-build-cmake.sdist] # What to include in source distributions
-include = [ "pybgcode/*", "src/*" , "deps/*", "deps/build.cmake", "cmake/*", "CMakeLists.txt", "CMakePresets.json"]
+include = ["pybgcode/*", "src/*" , "deps/*", "deps/build.cmake", "cmake/*", "CMakeLists.txt", "CMakePresets.json"]
 exclude = [".gitignore", ".git/", ".github/", "deps/build*", "build*", "CMakeLists.txt.user", "*.bak"]
 
 [tool.py-build-cmake.cmake] # How to build the CMake project
-source_path = "./pybgcode"
+source_path = "pybgcode"
 build_type = "Release"
 config = ["Release"]
 # generator = "Ninja"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pybgcode_jneilliii"
+name = "pybgcode-jneilliii"
 version = "0.2.0"
 description = "Prusa Block & Binary G-code reader / writer / converter"
 authors = [


### PR DESCRIPTION
1. Maybe the project name needs to match the repo name, hence using dash in both cases.

Indeed hyphens and underscores seem to be somewhat tricky in Python names. But what is particularly weird here, is that it seems to be "normalized" two times, and either way round:
- https://github.com/jneilliii/libbgcode-jneilliii/actions/runs/16125476696/job/45501244825?pr=9
  ```
    * Getting build dependencies for wheel...
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
    * Building wheel...
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
  ```
- https://github.com/jneilliii/libbgcode-jneilliii/actions/runs/16125266560/job/45500555797
  ```
    -- Configuring incomplete, errors occurred!
    /tmp/build-env-23oe5yxa/lib/python3.8/site-packages/py_build_cmake/config.py:102: UserWarning: Name changed from pybgcode_jneilliii to pybgcode-jneilliii
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
  ```
  From hyphen to underscore and back to hyphen?
- https://github.com/jneilliii/libbgcode-jneilliii/actions/runs/16125349837/job/45500827282
  ```
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
    * Building wheel...
    /tmp/build-env-z0n8mjmb/lib/python3.8/site-packages/py_build_cmake/config.py:102: UserWarning: Name changed from pybgcode_jneilliii to pybgcode-jneilliii
      warnings.warn(
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
  ```
  The other way round, and then a 3rd time back to underscore???

2. Renaming project sub dir, but keeping hyphen. Let's see whether it does find it despite normalization.
  Now I do not see the renaming anymore. Maybe it is just in attempt to find the non-existing sub directory, before giving up?
  EDIT: Ah no, it's back again.

Hyphens seem to be indeed not welcome in module names: https://dnmtechs.com/working-with-python-modules-containing-dashes-or-hyphens/
But underscores seem to cause issues with some build systems as well. And when importing a module it is another thing again: https://discuss.python.org/t/whats-up-with-scripts-and-hyphens-underscores/17571

3. Consequently using underscore leads to 4 times back and forth renaming, to underscore version finally, but while it looks for the project dir with underscore, it still does not find it 🤣:
  ```
    /tmp/build-env-jjpy0d6f/lib/python3.8/site-packages/py_build_cmake/config.py:102: UserWarning: Name changed from pybgcode_jneilliii to pybgcode-jneilliii
      warnings.warn(
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
    * Building wheel...
    /tmp/build-env-jjpy0d6f/lib/python3.8/site-packages/py_build_cmake/config.py:102: UserWarning: Name changed from pybgcode_jneilliii to pybgcode-jneilliii
    Name changed from pybgcode-jneilliii to pybgcode_jneilliii
      warnings.warn(
    Traceback (most recent call last):
  ...
    ValueError: No file/folder found for module pybgcode_jneilliii
  ```

4. Trying without underscore and hyphen ... same error 🤔. So dash or hyphen seems to not have been the issue.

5. Renaming the sub sub dir ... this seems to have been it. Now that dir name was still hardcoded in one of the cmake files.

6. Adjusting the dir name in another script.